### PR TITLE
Add support for printing fields with null value

### DIFF
--- a/src/main/scala/com/softwaremill/macros/customize/CustomizeImpl.scala
+++ b/src/main/scala/com/softwaremill/macros/customize/CustomizeImpl.scala
@@ -33,7 +33,7 @@ class CustomizeImpl(val c: whitebox.Context) {
               case List(q"new mask()") =>
                 accList :+ Literal(Constant("***"))
               case _ =>
-                accList :+ q"$field.toString"
+                accList :+ q""""" + $field """
             }
           case _ => c.abort(c.enclosingPosition, s"Cannot call .toString on field.")
         }

--- a/src/test/scala/ToStringMaskTest.scala
+++ b/src/test/scala/ToStringMaskTest.scala
@@ -33,10 +33,22 @@ class ToStringMaskTest extends FlatSpec with Matchers {
     // then
     u.toString should be("UserPrivate(1,***)")
   }
+
+  it should "work on fields with null value" in {
+    // given
+    val u = User40(3, null, null)
+
+    // then
+    u.toString should be("User40(3,***,null)")
+  }
+
 }
 
 @customize
 case class User30(id: Int, @mask email: String)
+
+@customize
+case class User40(id: Int, @mask email: String, something: String)
 
 @customize
 case class UserPrivate private(id: Int, @mask email: String)


### PR DESCRIPTION
This PR fixes an issue with NullPointerException being thrown while calling `.toString` on an instance which has null value assigned to one of the not masked fields.
