### PR TITLE
Added support for classes that have more than 22 fields.

### DIFF
--- a/src/main/scala/com/softwaremill/macros/customize/CustomizeImpl.scala
+++ b/src/main/scala/com/softwaremill/macros/customize/CustomizeImpl.scala
@@ -38,11 +38,13 @@ class CustomizeImpl(val c: whitebox.Context) {
           case _ => c.abort(c.enclosingPosition, s"Cannot call .toString on field.")
         }
       }
-      val treesAsTuple = Apply(Select(Ident(TermName("scala")), TermName("Tuple" + fieldListTree.length)), fieldListTree)
+      val treesAsString = fieldListTree.reduceLeftOption { (commaSeparatedFieldsString, fieldString) =>
+        q"$commaSeparatedFieldsString + ',' + $fieldString"
+      }
       val typeNameStrTree = Literal(Constant(typeName.toString))
       q"""
          override def toString = {
-          $typeNameStrTree + $treesAsTuple
+          $typeNameStrTree + '(' + ${treesAsString.getOrElse(Literal(Constant("")))} + ')'
          }
       """
     }

--- a/src/test/scala-2.11/com/softwaremill/macros/customize/ToStringMaskOnBigClassesTest.scala
+++ b/src/test/scala-2.11/com/softwaremill/macros/customize/ToStringMaskOnBigClassesTest.scala
@@ -1,0 +1,22 @@
+package com.softwaremill.macros.customize
+
+import org.scalatest.{FlatSpec, Matchers}
+
+class ToStringMaskOnBigClassesTest extends FlatSpec with Matchers {
+
+  behavior of "masking"
+
+  it should "work on classes with > 22 fields" in {
+    // given
+    val bc = BigClass(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 ,14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25)
+
+    // then
+    bc.toString should be("BigClass(***,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25)")
+  }
+
+  @customize
+  case class BigClass(@mask a1: Int, a2: Int, a3: Int, a4: Int, a5: Int, a6: Int, a7: Int, a8: Int, a9: Int, a10: Int,
+                      a11: Int, a12: Int, a13: Int, a14: Int,a15: Int, a16: Int, a17: Int, a18: Int, a19: Int, a20: Int,
+                      a21: Int, a22: Int, a23: Int, a24: Int, a25: Int)
+
+}

--- a/src/test/scala/ToStringMaskTest.scala
+++ b/src/test/scala/ToStringMaskTest.scala
@@ -42,6 +42,30 @@ class ToStringMaskTest extends FlatSpec with Matchers {
     u.toString should be("User40(3,***,null)")
   }
 
+  it should "work on classes without any fields" in {
+    // given
+    val ec = EmptyClass()
+
+    // then
+    ec.toString should be("EmptyClass()")
+  }
+
+  it should "work on classes with 1 field" in {
+    // given
+    val sc = SmallClass(100)
+
+    // then
+    sc.toString should be("SmallClass(***)")
+  }
+
+  it should "work on classes with > 22 fields" in {
+    // given
+    val bc = BigClass(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 ,14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25)
+
+    // then
+    bc.toString should be("BigClass(***,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25)")
+  }
+
 }
 
 @customize
@@ -52,6 +76,17 @@ case class User40(id: Int, @mask email: String, something: String)
 
 @customize
 case class UserPrivate private(id: Int, @mask email: String)
+
+@customize
+case class EmptyClass()
+
+@customize
+case class SmallClass(@mask n: Int)
+
+@customize
+case class BigClass(@mask a1: Int, a2: Int, a3: Int, a4: Int, a5: Int, a6: Int, a7: Int, a8: Int, a9: Int, a10: Int,
+                    a11: Int, a12: Int, a13: Int, a14: Int,a15: Int, a16: Int, a17: Int, a18: Int, a19: Int, a20: Int,
+                    a21: Int, a22: Int, a23: Int, a24: Int, a25: Int)
 
 object UserPrivate {
   def apply(email: String) = new UserPrivate(1, email)

--- a/src/test/scala/com/softwaremill/macros/customize/ToStringMaskTest.scala
+++ b/src/test/scala/com/softwaremill/macros/customize/ToStringMaskTest.scala
@@ -1,6 +1,7 @@
+package com.softwaremill.macros.customize
+
 import java.time.ZonedDateTime
 
-import com.softwaremill.macros.customize.{customize, mask}
 import org.scalatest.{FlatSpec, Matchers}
 
 class ToStringMaskTest extends FlatSpec with Matchers {
@@ -58,14 +59,6 @@ class ToStringMaskTest extends FlatSpec with Matchers {
     sc.toString should be("SmallClass(***)")
   }
 
-  it should "work on classes with > 22 fields" in {
-    // given
-    val bc = BigClass(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 ,14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25)
-
-    // then
-    bc.toString should be("BigClass(***,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25)")
-  }
-
 }
 
 @customize
@@ -82,11 +75,6 @@ case class EmptyClass()
 
 @customize
 case class SmallClass(@mask n: Int)
-
-@customize
-case class BigClass(@mask a1: Int, a2: Int, a3: Int, a4: Int, a5: Int, a6: Int, a7: Int, a8: Int, a9: Int, a10: Int,
-                    a11: Int, a12: Int, a13: Int, a14: Int,a15: Int, a16: Int, a17: Int, a18: Int, a19: Int, a20: Int,
-                    a21: Int, a22: Int, a23: Int, a24: Int, a25: Int)
 
 object UserPrivate {
   def apply(email: String) = new UserPrivate(1, email)


### PR DESCRIPTION
Current limitation came from the scala.Tuple-based implementation of the `toString` generated by Stringmask macro.

This PR introduces a new reduceLeftOption-based way of combining Trees, which allows us to get rid of `scala.Tuple`s
